### PR TITLE
nginx: increase client_body_timeout

### DIFF
--- a/admin_manual/installation/nginx-root.conf.sample
+++ b/admin_manual/installation/nginx-root.conf.sample
@@ -30,8 +30,9 @@ server {
     # could take several months.
     #add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload;" always;
 
-    # set max upload size
+    # set max upload size and increase upload timeout:
     client_max_body_size 512M;
+    client_body_timeout 300s;
     fastcgi_buffers 64 4K;
 
     # Enable gzip but do not remove ETag headers

--- a/admin_manual/installation/nginx-subdir.conf.sample
+++ b/admin_manual/installation/nginx-subdir.conf.sample
@@ -57,8 +57,9 @@ server {
     }
 
     location ^~ /nextcloud {
-        # set max upload size
+        # set max upload size and increase upload timeout:
         client_max_body_size 512M;
+        client_body_timeout 300s;
         fastcgi_buffers 64 4K;
 
         # Enable gzip but do not remove ETag headers


### PR DESCRIPTION
This should fix the errors initially reported in https://github.com/nextcloud/server/issues/15200 (slow upload connection runs in default nginx client_body_timeout of 60s.
